### PR TITLE
Remove 36MB of binaryen source code from wasm-opt-cxx-sys crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,8 @@ version = "0.110.0"
 dependencies = [
  "anyhow",
  "cc",
+ "cxx",
+ "cxx-build",
  "regex",
 ]
 

--- a/components/wasm-opt-cxx-sys/build.rs
+++ b/components/wasm-opt-cxx-sys/build.rs
@@ -1,5 +1,3 @@
-use std::path::{Path, PathBuf};
-
 fn main() -> anyhow::Result<()> {
     let mut builder = cxx_build::bridge("src/lib.rs");
 
@@ -17,33 +15,9 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let binaryen_dir = get_binaryen_dir()?;
-
     builder
         .include("src")
-        .include(binaryen_dir.join("src"))
         .compile("wasm-opt-cxx");
 
     Ok(())
-}
-
-/// Finds the binaryen source directory.
-///
-/// Duplicated in `wasm-opt-sys`. See there for docs.
-fn get_binaryen_dir() -> anyhow::Result<PathBuf> {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")?;
-    let manifest_dir = Path::new(&manifest_dir);
-    let binaryen_packaged_dir = manifest_dir.join("binaryen");
-    let binaryen_submodule_dir = manifest_dir.join("../../binaryen");
-
-    match (
-        binaryen_packaged_dir.is_dir(),
-        binaryen_submodule_dir.is_dir(),
-    ) {
-        (true, _) => Ok(binaryen_packaged_dir),
-        (_, true) => Ok(binaryen_submodule_dir),
-        (false, false) => anyhow::bail!(
-            "binaryen source directory doesn't exist (maybe `git submodule update --init`?)"
-        ),
-    }
 }

--- a/components/wasm-opt-sys/Cargo.toml
+++ b/components/wasm-opt-sys/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2018"
 documentation = "https://docs.rs/wasm-opt-sys"
 repository = "https://github.com/brson/wasm-opt-rs"
 readme = "README.md"
+links = "binaryen"
 
 [build-dependencies]
 anyhow = "1.0.58"
 cc = { version = "1.0.73", features = ["parallel"] }
+cxx-build = "1.0.72"
 regex = "1.6.0"
 
 [dependencies]
+cxx = "1.0.72"

--- a/components/wasm-opt-sys/src/lib.rs
+++ b/components/wasm-opt-sys/src/lib.rs
@@ -26,3 +26,9 @@
 /// huge rebuild times during development this crate currently suffers from.
 #[doc(hidden)]
 pub fn init() {}
+
+/// Just here so that cxx-build becomes willing to manage the set of include
+/// directories from this crate for downstream crates to include from. Perhaps
+/// cxx-build should stop making it necessary to put this.
+#[cxx::bridge]
+mod dummy {}

--- a/publish.sh
+++ b/publish.sh
@@ -15,15 +15,12 @@ RUST_DEPLOY_VERSION=1.56.0
 rustc +$RUST_DEPLOY_VERSION --version
 
 rm -rf ./components/wasm-opt-sys/binaryen
-rm -rf ./components/wasm-opt-cxx-sys/binaryen
 
 cp -r ./binaryen ./components/wasm-opt-sys/
-cp -r ./binaryen ./components/wasm-opt-cxx-sys/
 
 # Make sure we don't publish this recursive submodule.
 # Not needed by our build.
 rm -rf ./components/wasm-opt-sys/binaryen/third_party/googletest
-rm -rf ./components/wasm-opt-cxx-sys/binaryen/third_party/googletest
 
 # cargo +$RUST_DEPLOY_VERSION publish --manifest-path ./components/wasm-opt-sys/Cargo.toml --dry-run
 # cargo +$RUST_DEPLOY_VERSION publish --manifest-path ./components/wasm-opt-cxx-sys/Cargo.toml --dry-run


### PR DESCRIPTION
```console
$ wget https://static.crates.io/crates/wasm-opt-cxx-sys/wasm-opt-cxx-sys-0.110.0.crate
$ tar xf wasm-opt-cxx-sys-0.110.0.crate 
$ cd wasm-opt-cxx-sys-0.110.0/
$ du -sh
36M
```

That seems like an excessive amount of source code to duplicate into `wasm-opt-sys` + `wasm-opt-cxx-sys`.

This PR uses some of the functionality of "cxx-build as a build system" (https://cxx.rs/build/cargo.html) to let `wasm-opt-cxx-sys` include headers directly from `wasm-opt-sys`'s source tree.