### PR TITLE
Replace init hack with extern crate

### DIFF
--- a/components/wasm-opt-cxx-sys/src/lib.rs
+++ b/components/wasm-opt-cxx-sys/src/lib.rs
@@ -18,6 +18,24 @@
 
 pub use cxx;
 
+/// Hack to establish linkage to wasm-opt-sys.
+///
+/// It is a hack, possibly temporary, to convince rustc that the `wasm-opt`
+/// crate is actually using the `wasm-opt-sys` crate.
+///
+/// If `rustc` sees that Rust code in `wasm-opt-cxx-sys` does not directly
+/// reference any Rust code in `wasm-opt-sys`, then it won't even attempt to
+/// link it, which will lead the linker to not link in the necessary C++ code.
+///
+/// This is only a problem because all of the external function definitions for
+/// `wasm-opt` live inside the `wasm-opt-cxx-sys` crate, when they would
+/// normally live in `wasm-opt-sys` crate.
+///
+/// We have the external definitions living in the "wrong" crate to avoid the
+/// huge rebuild times during development that `wasm-opt-sys` currently suffers
+/// from.
+extern crate wasm_opt_sys;
+
 #[cxx::bridge(namespace = "Colors")]
 pub mod colors {
     unsafe extern "C++" {
@@ -193,14 +211,4 @@ pub mod wasm {
 
         fn checkPassOptionsDefaultsOs(pass_options: UniquePtr<PassOptions>) -> bool;
     }
-}
-
-/// Hack to establish linkage to wasm-opt-sys.
-///
-/// See docs for `wasm_opt_sys::init`.
-#[doc(hidden)]
-pub fn init() -> anyhow::Result<()> {
-    wasm_opt_sys::init();
-
-    Ok(())
 }

--- a/components/wasm-opt-sys/src/lib.rs
+++ b/components/wasm-opt-sys/src/lib.rs
@@ -8,21 +8,3 @@
 //!
 //! [`wasm-opt-cxx-sys`]: https//docs.rs/wasm-opt-cxx-sys
 //! [`wasm-opt`]: https://docs.rs/wasm-opt
-
-/// This needs to be called but doesn't do anything.
-///
-/// It is a hack, possibly temporary, to convince rustc that the `wasm-opt`
-/// crate is actually using the `wasm-opt-sys` crate.
-///
-/// If `rustc` sees that `wasm-opt` references nothing in this crate, then it
-/// won't even attempt to link to it, which will lead the linker to not link in
-/// the cpp code.
-///
-/// This is only a problem because all of the external function
-/// definitions for wasm-opt live inside the `wasm-opt-cxx-sys` crate,
-/// when they would normally live in this crate.
-///
-/// We have the external definitions living in the "wrong" crate to avoid the
-/// huge rebuild times during development this crate currently suffers from.
-#[doc(hidden)]
-pub fn init() {}

--- a/components/wasm-opt/src/main.rs
+++ b/components/wasm-opt/src/main.rs
@@ -1,6 +1,6 @@
-fn main() -> anyhow::Result<()> {
-    wasm_opt_sys::init();
+extern crate wasm_opt_sys;
 
+fn main() -> anyhow::Result<()> {
     wasm_opt_main()
 }
 


### PR DESCRIPTION
This is the intended way to make a crate force linkage of another crate. Also used in https://github.com/dtolnay/cxx/blob/1.0.78/src/lib.rs#L397-L398 for example to link the C++ standard library, as well as for all the various non-default sysroot crates, such as in https://github.com/dtolnay/syn/blob/1.0.102/tests/test_round_trip.rs#L7-L14.

The major advantage is you don't need to fool an optimizer into thinking that runtime control flow ever reaches the other crate.