### PR TITLE
Make cargo fmt CI job useful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Checkout submodule
-        run: git submodule update --init --recursive
       - run: cargo fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,4 +91,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Checkout submodule
         run: git submodule update --init --recursive
-      - run: cargo fmt
+      - run: cargo fmt --check


### PR DESCRIPTION
Previously it would only fail if rustfmt crashes on the code in this repo, which is not what I think it was intended to test. Using `--check` means the job will signal when the code being committed is not correctly formatted.

Separately I removed the `git submodule update --init --recursive` from the fmt job because it is unnecessary and slow.