### PR TITLE
Make feature selection work like binaryen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 ## 0.111.0
 
 - Upgraded to Binaryen 111.
-- Binaryen now enables the `SignExt` and `MutableGlobal` features by default,
+- Binaryen now enables the `SignExt` and `MutableGlobals` features by default,
   which are also enabled in the LLVM backend.
   In the future Binaryen will align its default feature selection with the LLVM backend.
   To get the same feature selection as Binaryen 110, call
 
   ```rust
-      opts.disable_feature(Feature::SignExt)
-          .disable_feature(Feature::MutableGlobals)
+      opts.mvp_features_only()
   ```
 - The `TypedFunctionReferences` feature has been removed. The CLI still accepts
   `--enable-typed-function-references` and `--disabled-type-function-references`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.111.0
 
 - Upgraded to Binaryen 111.
+- [Fixed bugs in feature selection via the API](https://github.com/brson/wasm-opt-rs/issues/123).
 - Binaryen now enables the `SignExt` and `MutableGlobals` features by default,
   which are also enabled in the LLVM backend.
   In the future Binaryen will align its default feature selection with the LLVM backend.

--- a/components/wasm-opt-cxx-sys/src/lib.rs
+++ b/components/wasm-opt-cxx-sys/src/lib.rs
@@ -159,7 +159,11 @@ pub mod wasm {
 
         fn setAll(self: Pin<&mut Self>);
 
-        fn set(self: Pin<&mut Self>, feature: u32);
+        fn set(self: Pin<&mut Self>, feature: u32, val: bool);
+
+        fn has(self: &Self, features: &WasmFeatureSet) -> bool;
+
+        fn as_int(self: &Self) -> u32;
 
         fn getFeatureArray() -> UniquePtr<CxxVector<u32>>;
 

--- a/components/wasm-opt-cxx-sys/src/lib.rs
+++ b/components/wasm-opt-cxx-sys/src/lib.rs
@@ -59,12 +59,6 @@ pub mod wasm {
             wasm: Pin<&mut Module>,
         ) -> Result<()>;
 
-        fn ModuleReader_readText(
-            reader: &UniquePtr<ModuleReader>,
-            filename: Pin<&mut CxxString>,
-            wasm: Pin<&mut Module>,
-        ) -> Result<()>;
-
         fn readBinary(
             self: Pin<&mut Self>,
             filename: Pin<&mut CxxString>,

--- a/components/wasm-opt-cxx-sys/src/shims.h
+++ b/components/wasm-opt-cxx-sys/src/shims.h
@@ -226,8 +226,16 @@ namespace wasm_shims {
       inner.setAll();
     }
 
-    void set(uint32_t feature) {
-      inner.set(feature);
+    void set(uint32_t feature, bool val) {
+      inner.set(feature, val);
+    }
+
+    bool has(const WasmFeatureSet& features) const {
+      return inner.has(features.inner);
+    }
+
+    uint32_t as_int() const {
+      return inner;
     }
   };
 

--- a/components/wasm-opt-cxx-sys/src/shims.h
+++ b/components/wasm-opt-cxx-sys/src/shims.h
@@ -79,11 +79,6 @@ namespace wasm_shims {
   std::unique_ptr<ModuleReader> newModuleReader() {
     return std::make_unique<ModuleReader>();
   }
-
-  void ModuleReader_readText(const std::unique_ptr<ModuleReader> &reader, std::string& filename, Module& wasm) {
-    reader->inner.readText(std::move(filename), wasm);
-  }
-
 }
 
 namespace wasm_shims {

--- a/components/wasm-opt/src/api.rs
+++ b/components/wasm-opt/src/api.rs
@@ -180,24 +180,31 @@ pub struct Passes {
 }
 
 /// Which wasm [`Feature`]s to enable and disable.
-///
-/// Disabling [`Feature::Mvp`] means no features are disabled.
+#[derive(Clone, Debug, Default)]
+pub struct Features {
+    pub baseline: FeatureBaseline,
+    pub enabled: HashSet<Feature>,
+    pub disabled: HashSet<Feature>,
+}
+
+/// The set of features to apply before applying custom features.
 #[derive(Clone, Debug)]
-pub enum Features {
+pub enum FeatureBaseline {
+    /// The default Binaryen feature set.
+    ///
     /// Enables [`Feature::Default`].
     /// Disables [`Feature::None`].
     Default,
+    /// Only allow WebAssembly MVP features.
+    ///
     /// Enables [`Feature::Mvp`].
     /// Disables [`Feature::All`].
     MvpOnly,
+    /// Allow all features.
+    ///
     /// Enables [`Feature::All`].
     /// Disables [Feature::Mvp`].
     All,
-    /// Specify which features to enable and disable.
-    Custom {
-        enabled: HashSet<Feature>,
-        disabled: HashSet<Feature>,
-    },
 }
 
 /// Constructors.
@@ -379,8 +386,8 @@ impl Default for Passes {
     }
 }
 
-impl Default for Features {
-    fn default() -> Features {
-        Features::Default
+impl Default for FeatureBaseline {
+    fn default() -> FeatureBaseline {
+        FeatureBaseline::Default
     }
 }

--- a/components/wasm-opt/src/api.rs
+++ b/components/wasm-opt/src/api.rs
@@ -180,6 +180,9 @@ pub struct Passes {
 }
 
 /// Which wasm [`Feature`]s to enable and disable.
+///
+/// The baseline features are applied first, then
+/// enabled and disabled features are applied.
 #[derive(Clone, Debug, Default)]
 pub struct Features {
     pub baseline: FeatureBaseline,

--- a/components/wasm-opt/src/base.rs
+++ b/components/wasm-opt/src/base.rs
@@ -281,9 +281,19 @@ impl FeatureSet {
         this.setAll();
     }
 
-    pub fn set(&mut self, feature: Feature) {
+    pub fn set(&mut self, feature: Feature, val: bool) {
         let this = self.0.pin_mut();
-        this.set(feature as u32);
+        this.set(feature as u32, val);
+    }
+
+    pub fn has(&self, features: &FeatureSet) -> bool {
+        //let this = self.0.pin();
+        //let other = features.0.pin();
+        self.0.has(&*features.0)
+    }
+
+    pub fn as_int(&self) -> u32 {
+        self.0.as_int()
     }
 }
 
@@ -295,7 +305,7 @@ pub fn get_feature_array() -> Vec<u32> {
     feature_vec
 }
 
-#[derive(Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter)]
 pub enum Feature {
     None = 0,
     Atomics = 1 << 0,

--- a/components/wasm-opt/src/builder.rs
+++ b/components/wasm-opt/src/builder.rs
@@ -1,7 +1,6 @@
 //! A builder API for `OptimizationOptions`.
 
 use crate::api::*;
-use std::collections::HashSet;
 
 /// Builder methods.
 impl OptimizationOptions {
@@ -127,61 +126,35 @@ impl OptimizationOptions {
         self
     }
 
-    /// Sets [`OptimizationOptions::features`] to [`Features::MvpOnly`].
+    /// Sets the baseline feature set to [`FeatureBaseline::MvpOnly`].
     pub fn mvp_features_only(&mut self) -> &mut Self {
-        self.features = Features::MvpOnly;
+        self.features.baseline = FeatureBaseline::MvpOnly;
         self
     }
 
-    /// Sets [`OptimizationOptions::features`] to [`Features::All`].
+    /// Sets the baseline feature set to [`FeatureBaseline::All`].
     pub fn all_features(&mut self) -> &mut Self {
-        self.features = Features::All;
+        self.features.baseline = FeatureBaseline::All;
         self
     }
 
-    /// Adds a feature to [`Features::Custom::enabled`].
+    /// Enables a feature.
     ///
-    /// Sets [`OptimizationOptions::features`] to [`Features::Custom`] if not already.
+    /// This adds the feature to [`Features::enabled`] and removes it from
+    /// [`Features::disabled`].
     pub fn enable_feature(&mut self, feature: Feature) -> &mut Self {
-        match &mut self.features {
-            Features::Default | Features::MvpOnly | Features::All => {
-                self.features = Features::Custom {
-                    enabled: HashSet::new(),
-                    disabled: HashSet::new(),
-                };
-                self.enable_feature(feature)
-            }
-            Features::Custom {
-                enabled: enabled_features,
-                disabled: disabled_features,
-            } => {
-                enabled_features.insert(feature);
-                disabled_features.remove(&feature);
-                self
-            }
-        }
+        self.features.enabled.insert(feature);
+        self.features.disabled.remove(&feature);
+        self
     }
 
-    /// Adds a feature to [`Features::Custom::disabled`].
+    /// Disables a feature.
     ///
-    /// Sets [`OptimizationOptions::features`] to [`Features::Custom`] if not already.
+    /// This adds the feature to [`Features::disabled`] and removes it from
+    /// [`Features::enabled`].
     pub fn disable_feature(&mut self, feature: Feature) -> &mut Self {
-        match &mut self.features {
-            Features::Default | Features::MvpOnly | Features::All => {
-                self.features = Features::Custom {
-                    enabled: HashSet::new(),
-                    disabled: HashSet::new(),
-                };
-                self.disable_feature(feature)
-            }
-            Features::Custom {
-                enabled: enabled_features,
-                disabled: disabled_features,
-            } => {
-                enabled_features.remove(&feature);
-                disabled_features.insert(feature);
-                self
-            }
-        }
+        self.features.enabled.remove(&feature);
+        self.features.disabled.insert(feature);
+        self
     }
 }

--- a/components/wasm-opt/src/builder.rs
+++ b/components/wasm-opt/src/builder.rs
@@ -140,20 +140,16 @@ impl OptimizationOptions {
 
     /// Enables a feature.
     ///
-    /// This adds the feature to [`Features::enabled`] and removes it from
-    /// [`Features::disabled`].
+    /// This adds the feature to [`Features::enabled`].
     pub fn enable_feature(&mut self, feature: Feature) -> &mut Self {
         self.features.enabled.insert(feature);
-        self.features.disabled.remove(&feature);
         self
     }
 
     /// Disables a feature.
     ///
-    /// This adds the feature to [`Features::disabled`] and removes it from
-    /// [`Features::enabled`].
+    /// This adds the feature to [`Features::disabled`].
     pub fn disable_feature(&mut self, feature: Feature) -> &mut Self {
-        self.features.enabled.remove(&feature);
         self.features.disabled.insert(feature);
         self
     }

--- a/components/wasm-opt/src/builder.rs
+++ b/components/wasm-opt/src/builder.rs
@@ -140,7 +140,8 @@ impl OptimizationOptions {
 
     /// Enables a feature.
     ///
-    /// This adds the feature to [`Features::enabled`].
+    /// This adds the feature to [`Features::enabled`], and is equivalent to the
+    /// `--enable-{feature}` command line arguments.
     pub fn enable_feature(&mut self, feature: Feature) -> &mut Self {
         self.features.enabled.insert(feature);
         self
@@ -148,7 +149,8 @@ impl OptimizationOptions {
 
     /// Disables a feature.
     ///
-    /// This adds the feature to [`Features::disabled`].
+    /// This adds the feature to [`Features::disabled`], and is equivalent to
+    /// the `--disable-{feature}` command line arguments.
     pub fn disable_feature(&mut self, feature: Feature) -> &mut Self {
         self.features.disabled.insert(feature);
         self

--- a/components/wasm-opt/src/builder.rs
+++ b/components/wasm-opt/src/builder.rs
@@ -152,10 +152,11 @@ impl OptimizationOptions {
                 self.enable_feature(feature)
             }
             Features::Custom {
-                enabled: features,
-                disabled: _,
+                enabled: enabled_features,
+                disabled: disabled_features,
             } => {
-                features.insert(feature);
+                enabled_features.insert(feature);
+                disabled_features.remove(&feature);
                 self
             }
         }
@@ -174,10 +175,11 @@ impl OptimizationOptions {
                 self.disable_feature(feature)
             }
             Features::Custom {
-                enabled: _,
-                disabled: features,
+                enabled: enabled_features,
+                disabled: disabled_features,
             } => {
-                features.insert(feature);
+                enabled_features.remove(&feature);
+                disabled_features.insert(feature);
                 self
             }
         }

--- a/components/wasm-opt/src/features.rs
+++ b/components/wasm-opt/src/features.rs
@@ -11,7 +11,7 @@ use strum_macros::EnumString;
 /// used where.
 ///
 /// [rm]: https://webassembly.org/roadmap/
-#[derive(Clone, Debug, Eq, Hash, PartialEq, EnumString)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumString)]
 pub enum Feature {
     /// None.
     #[strum(disabled)]

--- a/components/wasm-opt/src/run.rs
+++ b/components/wasm-opt/src/run.rs
@@ -349,6 +349,25 @@ mod test {
                    BaseFeature::Default as u32);
         assert_eq!(disabled.as_int(),
                    BaseFeature::None as u32);
+
+        assert!(has(&enabled, BaseFeature::SignExt));
+        assert!(!has(&disabled, BaseFeature::SignExt));
+        assert!(has(&enabled, BaseFeature::MutableGlobals));
+        assert!(!has(&disabled, BaseFeature::MutableGlobals));
+    }
+
+    #[test]
+    fn test_features_remove_defaults() {
+        let mut opts = OptimizationOptions::new_optimize_for_size();
+        opts
+            .disable_feature(Feature::SignExt)
+            .disable_feature(Feature::MutableGlobals);
+        let (enabled, disabled) = convert_feature_sets(&opts.features);
+
+        assert!(!has(&enabled, BaseFeature::SignExt));
+        assert!(has(&disabled, BaseFeature::SignExt));
+        assert!(!has(&enabled, BaseFeature::MutableGlobals));
+        assert!(has(&disabled, BaseFeature::MutableGlobals));
     }
 
     #[test]

--- a/components/wasm-opt/src/run.rs
+++ b/components/wasm-opt/src/run.rs
@@ -223,10 +223,7 @@ impl OptimizationOptions {
     }
 
     fn apply_features(&self, m: &mut Module) {
-        let (enabled_features, disabled_features) =
-            convert_feature_sets(
-                &self.features,
-            );
+        let (enabled_features, disabled_features) = convert_feature_sets(&self.features);
 
         m.apply_features(enabled_features, disabled_features);
     }
@@ -268,9 +265,7 @@ fn will_remove_debug_info(passes: &[Pass]) -> bool {
         .any(|pass| PassRunner::pass_removes_debug_info(pass.name()) == true)
 }
 
-fn convert_feature_sets(
-    features: &Features,
-) -> (BaseFeatureSet, BaseFeatureSet) {
+fn convert_feature_sets(features: &Features) -> (BaseFeatureSet, BaseFeatureSet) {
     let mut feature_set_enabled = BaseFeatureSet::new();
     let mut feature_set_disabled = BaseFeatureSet::new();
 
@@ -302,7 +297,7 @@ fn convert_feature_sets(
 
     (feature_set_enabled, feature_set_disabled)
 }
-        
+
 fn convert_feature(feature: &Feature) -> BaseFeature {
     match feature {
         Feature::None => BaseFeature::None,
@@ -345,10 +340,8 @@ mod test {
         let features = Features::default();
         let (enabled, disabled) = convert_feature_sets(&features);
 
-        assert_eq!(enabled.as_int(),
-                   BaseFeature::Default as u32);
-        assert_eq!(disabled.as_int(),
-                   BaseFeature::None as u32);
+        assert_eq!(enabled.as_int(), BaseFeature::Default as u32);
+        assert_eq!(disabled.as_int(), BaseFeature::None as u32);
 
         assert!(has(&enabled, BaseFeature::SignExt));
         assert!(!has(&disabled, BaseFeature::SignExt));
@@ -359,8 +352,7 @@ mod test {
     #[test]
     fn test_features_remove_defaults() {
         let mut opts = OptimizationOptions::new_optimize_for_size();
-        opts
-            .disable_feature(Feature::SignExt)
+        opts.disable_feature(Feature::SignExt)
             .disable_feature(Feature::MutableGlobals);
         let (enabled, disabled) = convert_feature_sets(&opts.features);
 
@@ -384,7 +376,7 @@ mod test {
         assert!(has(&disabled, BaseFeature::Gc));
 
         opts.enable_feature(Feature::Gc);
-        
+
         let (enabled, disabled) = convert_feature_sets(&opts.features);
 
         assert!(has(&enabled, BaseFeature::Gc));
@@ -410,7 +402,7 @@ mod test {
         assert!(!has(&disabled, BaseFeature::Gc));
 
         opts.disable_feature(Feature::Gc);
-        
+
         let (enabled, disabled) = convert_feature_sets(&opts.features);
 
         assert!(!has(&enabled, BaseFeature::Gc));


### PR DESCRIPTION
Feature selection basically didn't work previously: either you got the MVP features, all features, or the default features + custom enabled and disabled features; and enabling / disabling did not work the same way as wasm-opt. Now you get a baseline set of features, either default, mvp, or all, and stack enables/disables on top of that, and enabling disabling changes the enabled/disabled set the same way binaryen does.

Fixes https://github.com/brson/wasm-opt-rs/issues/123