### PR TITLE
Conformity to binaryen's modifications to DWARF

### DIFF
--- a/components/conformance-tests/tests/tests.rs
+++ b/components/conformance-tests/tests/tests.rs
@@ -251,6 +251,15 @@ fn get_test_infile_wasm() -> Result<PathBuf> {
     Ok(infile)
 }
 
+fn get_test_infile_wasm_alt() -> Result<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")?;
+    let manifest_dir = PathBuf::from(manifest_dir);
+    let workspace = manifest_dir.join("../..");
+    let infile = workspace.join("components/wasm-opt/tests/hello_world.wasm");
+
+    Ok(infile)
+}
+
 fn get_test_infile_wat() -> Result<PathBuf> {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")?;
     let manifest_dir = PathBuf::from(manifest_dir);
@@ -877,4 +886,23 @@ fn check_versions() -> Result<()> {
     assert_eq!(version_binaryen, version_rust);
 
     Ok(())
+}
+
+#[test]
+fn dwarf_line_info() -> Result<()> {
+    let infile = get_test_infile_wasm_alt()?;
+    let outfile = PathBuf::from("outfile.wasm");
+
+    let infile_sourcemap = None::<PathBuf>;
+    let outfile_sourcemap = None::<PathBuf>;
+
+    let args = vec![];
+
+    run_test(TestArgs {
+        infile,
+        infile_sourcemap,
+        outfile,
+        outfile_sourcemap,
+        args,
+    })
 }

--- a/components/wasm-opt-cxx-sys/build.rs
+++ b/components/wasm-opt-cxx-sys/build.rs
@@ -5,9 +5,9 @@ fn main() -> anyhow::Result<()> {
         let target_env = std::env::var("CARGO_CFG_TARGET_ENV")?;
 
         let flags: &[_] = if target_env != "msvc" {
-            &["-std=c++17", "-Wno-unused-parameter"]
+            &["-std=c++17", "-Wno-unused-parameter", "-DBUILD_LLVM_DWARF"]
         } else {
-            &["/std:c++17"]
+            &["/std:c++17", "/DBUILD_LLVM_DWARF"]
         };
 
         for flag in flags {

--- a/components/wasm-opt-sys/build.rs
+++ b/components/wasm-opt-sys/build.rs
@@ -358,13 +358,15 @@ fn check_cxx17_support() -> anyhow::Result<()> {
 
 fn get_llvm_files(llvm_dir: &Path) -> anyhow::Result<[PathBuf; 63]> {
     let llvm_dwarf = disambiguate_file(&llvm_dir.join("Dwarf.cpp"), "LLVMDwarf.cpp")?;
-    // Array taken from https://github.com/WebAssembly/binaryen/blob/third_party/llvm-project/CMakeLists.txt
+    let llvm_debug = disambiguate_file(&llvm_dir.join("Debug.cpp"), "LLVMDebug.cpp")?;
+    // Array taken from
+    // https://github.com/WebAssembly/binaryen/blob/616c08bc1ec604a822d354cbb0353b7994cec72d/third_party/llvm-project/CMakeLists.txt
     Ok([
-        llvm_dir.join("Debug.cpp"),
         llvm_dir.join("Binary.cpp"),
         llvm_dir.join("ConvertUTF.cpp"),
         llvm_dir.join("DataExtractor.cpp"),
         llvm_dir.join("DJB.cpp"),
+        llvm_debug,
         llvm_dir.join("dwarf2yaml.cpp"),
         llvm_dir.join("DWARFAbbreviationDeclaration.cpp"),
         llvm_dir.join("DWARFAcceleratorTable.cpp"),

--- a/components/wasm-opt-sys/build.rs
+++ b/components/wasm-opt-sys/build.rs
@@ -54,6 +54,7 @@ fn main() -> anyhow::Result<()> {
         let flags: &[_] = if target_env != "msvc" {
             &[
                 "-std=c++17",
+                "-w",
                 "-Wno-unused-parameter",
                 "-DTHROW_ON_FATAL",
                 "-DBUILD_LLVM_DWARF",
@@ -62,6 +63,7 @@ fn main() -> anyhow::Result<()> {
         } else {
             &[
                 "/std:c++17",
+                "/w",
                 "/DTHROW_ON_FATAL",
                 "/DBUILD_LLVM_DWARF",
                 "/DNDEBUG",


### PR DESCRIPTION
This PR includes the third party LLVM source used in binaryen. This is necessary because the related DWARF stuff depends on this LLVM code. Along with `BUILD_LLVM_DWARF`, I set `NDEBUG`, as I ran into a linker error without it. This is done by CMake automatically in binaryen anyway, so this is still conforming to the upstream `wasm-opt`.

Lastly, I had to silence warnings because LLVM uses some deprecated APIs. [binaryen silences these cleanly with CMake](https://github.com/WebAssembly/binaryen/blob/616c08bc1ec604a822d354cbb0353b7994cec72d/third_party/llvm-project/CMakeLists.txt#L5), but I'm not sure how to do the same with `cxx_build`. So, for the time being at least, `-w` is passed to the compiler.

Related issue: #150.