### PR TITLE
Fix small typo when reading modules

### DIFF
--- a/components/wasm-opt/src/run.rs
+++ b/components/wasm-opt/src/run.rs
@@ -114,8 +114,8 @@ impl OptimizationOptions {
             reader.set_dwarf(set_dwarf);
 
             match self.reader.file_type {
-                FileType::Wasm => reader.read_text(infile, &mut m),
-                FileType::Wat => reader.read_binary(infile, &mut m, infile_sourcemap),
+                FileType::Wasm => reader.read_binary(infile, &mut m, infile_sourcemap),
+                FileType::Wat => reader.read_text(infile, &mut m),
                 FileType::Any => reader.read(infile, &mut m, infile_sourcemap),
             }
             .map_err(|e| OptimizationError::Read {


### PR DESCRIPTION
Makes `OptimizationOptions::reader_file_type()` usable.