### PR TITLE
fix: allow compiling to wasm32-wasi

### DIFF
--- a/components/wasm-opt/src/base.rs
+++ b/components/wasm-opt/src/base.rs
@@ -391,8 +391,8 @@ fn convert_path_to_u8(path: &Path) -> Result<&[u8], cxx::Exception> {
     #[cfg(unix)]
     let path = path.as_os_str().as_bytes();
 
-    #[cfg(windows)]
-    let path = path.as_os_str().to_str().expect("utf8").as_bytes();
+    #[cfg(not(unix))]
+    let path = path.to_str().expect("utf8").as_bytes();
 
     Ok(path)
 }


### PR DESCRIPTION
This fixes a type mismatch when compiling `wasm-opt` targeting `wasm32-wasi`.
```
error[E0308]: mismatched types
   --> wasm-opt-0.116.0/src/base.rs:397:8
    |
397 |     Ok(path)
    |     -- ^^^^ expected `&[u8]`, found `&Path`
    |     |
    |     arguments to this enum variant are incorrect
    |
    = note: expected reference `&[u8]`
               found reference `&Path`
```

cc @alexcrichton